### PR TITLE
Logger is outdated

### DIFF
--- a/lib/itamae/plugin/resource/iptables_chain.rb
+++ b/lib/itamae/plugin/resource/iptables_chain.rb
@@ -11,7 +11,7 @@ module Itamae
         def set_current_attributes
           current.exist = run_command(['iptables', '--table', attributes.table, '--list-rules', attributes.chain], error: false).exit_status == 0
           unless current.exist
-            Logger.info "Create chain #{attributes.chain}"
+            Itamae.logger.info "Create chain #{attributes.chain}"
           end
         end
 

--- a/lib/itamae/plugin/resource/iptables_rule.rb
+++ b/lib/itamae/plugin/resource/iptables_rule.rb
@@ -33,7 +33,7 @@ module Itamae
           rule = build_rule(attributes)
           current.exist = run_command(['iptables', '--table', attributes.table, '--check', attributes.chain] + rule, error: false).exit_status == 0
           unless current.exist
-            Logger.info "Create rule for #{attributes.chain}: #{rule.join(' ')}"
+            Itamae.logger.info "Create rule for #{attributes.chain}: #{rule.join(' ')}"
           end
         end
 


### PR DESCRIPTION
Use `Itamae.logger` instead of `Logger`.
from itamae v1.5.0
